### PR TITLE
New outcome process

### DIFF
--- a/paper/simulations.py
+++ b/paper/simulations.py
@@ -54,7 +54,7 @@ def dgp1_true_ratio_stabilized_weight(a, x):
 
 
 def dgp1_true_outcome(a, x, key):
-    mu = a.squeeze() + x[..., 0] * x[..., 1] + x[..., 2]
+    mu = a.squeeze() * (1 + jnp.square(x[..., 0])) + x[..., 0] * x[..., 1] + x[..., 2]
     num_samples = len(mu)
     return jax.random.normal(key, shape=(num_samples,)) + mu
 


### PR DESCRIPTION
The old outcome process was too simple to be informative for average dose response curve learing because it satisfied $$E_{P_1}[\mu(X)] = E_{P_0}[\mu(X)]$$ due to the linearity of $\mu(x)$.