### PR TITLE
Clear JAX cache

### DIFF
--- a/paper/simulations.py
+++ b/paper/simulations.py
@@ -236,6 +236,10 @@ def run_simulations(
     for iteration, k in enumerate(jax.random.split(key, num_simulations)):
         logger.info(f"Starting simulation: {iteration}")
 
+        # Issue when running on EC2 instance after around 20 iterations
+        # See also https://github.com/jax-ml/jax/issues/11923
+        jax.clear_caches()
+
         k_train, k_valid, k_test, k_outcome = jax.random.split(k, 4)
         # Use 80/20 test validation split
         num_train = int(num_samples * 0.8)


### PR DESCRIPTION
On the EC2 instance we see the error after 20 iterations
```
E0919 16:42:12.530719  102005 execution_engine.cc:54] LLVM compilation error: Cannot allocate memory
```
This seems to relate to JAX caching, so this PR tries to clear the cache