### PR TITLE
KDE for shift intervention

### DIFF
--- a/paper/models/shift.yaml
+++ b/paper/models/shift.yaml
@@ -8,6 +8,8 @@ augmentation_params:
 # Model parameters
 kde:
   model: kde
+  method: shift
+  shift_size: 0.1
 
 kliep:
   model: kernel

--- a/paper/models/stabilized_weights_mc.yaml
+++ b/paper/models/stabilized_weights_mc.yaml
@@ -10,7 +10,7 @@ augmentation_params:
 # Model parameters
 kde:
   model: kde
-  stabilized_weight: True
+  method: stabilized_weight
 
 kliep:
   model: kernel

--- a/paper/models/stabilized_weights_mc_derange.yaml
+++ b/paper/models/stabilized_weights_mc_derange.yaml
@@ -10,7 +10,7 @@ augmentation_params:
 # Model parameters
 kde:
   model: kde
-  stabilized_weight: True
+  method: stabilized_weight
 
 kliep:
   model: kernel

--- a/paper/models/stabilized_weights_mc_shuffle.yaml
+++ b/paper/models/stabilized_weights_mc_shuffle.yaml
@@ -10,7 +10,7 @@ augmentation_params:
 # Model parameters
 kde:
   model: kde
-  stabilized_weight: True
+  method: stabilized_weight
 
 kliep:
   model: kernel

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -145,14 +145,14 @@ def test_kernel_training(augmented_data, test_data, method):
     assert preds.shape == (len(a),)
 
 
-@pytest.mark.parametrize("stabilized_weight", [True, False])
-def test_kde_training(augmented_data, test_data, stabilized_weight):
+@pytest.mark.parametrize("method", [None, "stabilized_weight", "shift"])
+def test_kde_training(augmented_data, test_data, method):
     delta, x_augmented, w_augmented = augmented_data
     model = train_kde(
         y=delta,
         x=x_augmented,
         weights=w_augmented,
-        params={"stabilized_weight": stabilized_weight},
+        params={"method": method, "shift_size": 0.1},
     )
     a, x = test_data
     preds = model.predict(np.column_stack([a, x]))


### PR DESCRIPTION
We want to compare against a baseline KDE where the density is learned once and the numerator density is estimated by applying the treatment shift